### PR TITLE
Chore: fill Sales Person in Payment entry

### DIFF
--- a/vizpay/vizpay/doctype/vizpay_transaction/vizpay_transaction.py
+++ b/vizpay/vizpay/doctype/vizpay_transaction/vizpay_transaction.py
@@ -96,6 +96,8 @@ class VizpayTransaction(Document):
 		payment_entry.setup_party_account_field()
 		payment_entry.set_missing_values()
 
+		payment_entry.sales_person = frappe.db.get_value("Sales Person", {"user": payment_entry.owner}, "name")
+
 		if auto_allocate:
 			outstanding_docs = get_outstanding_reference_documents(
 				{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment entries now automatically assign the appropriate sales person during payment completion based on the payment initiator's information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->