### PR TITLE
Revert "Chore: fill Sales Person in Payment entry"

### DIFF
--- a/vizpay/vizpay/doctype/vizpay_transaction/vizpay_transaction.py
+++ b/vizpay/vizpay/doctype/vizpay_transaction/vizpay_transaction.py
@@ -96,8 +96,6 @@ class VizpayTransaction(Document):
 		payment_entry.setup_party_account_field()
 		payment_entry.set_missing_values()
 
-		payment_entry.sales_person = frappe.db.get_value("Sales Person", {"user": payment_entry.owner}, "name")
-
 		if auto_allocate:
 			outstanding_docs = get_outstanding_reference_documents(
 				{


### PR DESCRIPTION
Reverts wahni-green/vizpay#7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic sales person assignment when marking payments as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->